### PR TITLE
ColumnLength: Change default string size to 65535

### DIFF
--- a/core/src/main/scala/org/scalarelational/column/property/ColumnLength.scala
+++ b/core/src/main/scala/org/scalarelational/column/property/ColumnLength.scala
@@ -9,6 +9,6 @@ case class ColumnLength(length: Int) extends ColumnProperty {
 
 object ColumnLength {
   val Name = "columnLength"
-  val DefaultVarChar = Int.MaxValue
+  val DefaultVarChar = 65535
   val DefaultBinary  = 1000
 }


### PR DESCRIPTION
As per #22.