### PR TITLE
Add PostgreSQL Support (Addresses Issue #36)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_script:
   - mysql -e 'create database tablespec;'
   - mysql -e 'create database cross_reference;'
   - mysql -e 'create database special_types;'
-  - psql -c "create user travis with password 'pa';" -U postgres
   - psql -c 'create database tablespec owner travis;' -U postgres
   - psql -c 'create database cross_reference owner travis;' -U postgres
   - psql -c 'create database special_types owner travis;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ before_script:
   - mysql -e 'create database tablespec;'
   - mysql -e 'create database cross_reference;'
   - mysql -e 'create database special_types;'
+  - psql -c "create user travis with password 'pa';" -U postgres
+  - psql -c 'create database tablespec owner travis;' -U postgres
+  - psql -c 'create database cross_reference owner travis;' -U postgres
+  - psql -c 'create database special_types owner travis;' -U postgres

--- a/postgresql/src/main/scala/org/scalarelational/postgresql/PostgreSQL.scala
+++ b/postgresql/src/main/scala/org/scalarelational/postgresql/PostgreSQL.scala
@@ -1,0 +1,17 @@
+package org.scalarelational.postgresql
+
+/**
+ * @author Robert Djubek <envy1988@gmail.com>
+ */
+object PostgreSQL {
+
+  case class SSL(sslFactory: Option[String] = None, sslFactoryArg: Option[String] = None)
+
+  case class Config(host: String,
+                      schema: String,
+                      user: String,
+                      password: String,
+                      port: Int = 5432,
+                      ssl: Option[PostgreSQL.SSL] = None
+                       )
+}

--- a/postgresql/src/main/scala/org/scalarelational/postgresql/PostgreSQLDatastore.scala
+++ b/postgresql/src/main/scala/org/scalarelational/postgresql/PostgreSQLDatastore.scala
@@ -1,0 +1,145 @@
+package org.scalarelational.postgresql
+
+import javax.sql.DataSource
+
+import org.postgresql.ds.PGSimpleDataSource
+import org.powerscala.log.{Level, Logging}
+import org.powerscala.property.Property
+import org.scalarelational.column.ColumnPropertyContainer
+import org.scalarelational.column.property.{AutoIncrement, Polymorphic, Unique}
+import org.scalarelational.datatype._
+import org.scalarelational.instruction.ddl.CreateColumn
+import org.scalarelational.model._
+import org.scalarelational.op.{Condition, RegexCondition}
+import org.scalarelational.result.ResultSetIterator
+
+import scala.collection.mutable.ListBuffer
+
+/**
+ * @author Robert Djubek <envy1988@gmail.com>
+ */
+
+sealed trait PGSsl
+case class PGUseSsl(sslfactory: Option[String] = None, sslfactoryarg: Option[String] = None ) extends PGSsl
+case class PGNoSsl() extends PGSsl
+
+case class PGConfig(host: String,
+                            schema: String,
+                            user: String,
+                            password: String,
+                            port: Int = 5432,
+                            useSsl: PGSsl = PGNoSsl()
+                           )
+
+abstract class PostgreSQLDatastore private() extends SQLDatastore with Logging with SQLLogging {
+  protected def this(pgConfig: PGConfig) = {
+    this()
+    sqlLogLevel := Level.Warn
+    config := pgConfig
+  }
+
+  override def supportsMerge = false
+
+  protected def this(dataSource: DataSource) = {
+    this()
+    dataSourceProperty := dataSource
+  }
+
+  Class.forName("org.postgresql.Driver")
+
+  val config = Property[PGConfig]()
+
+  init()
+
+  protected def init() = {
+    config.change.on {
+      case evt => updateDataSource() // Update the data source if the mode changes
+    }
+  }
+
+  def updateDataSource() = {
+    dispose() // Make sure to shut down the previous DataSource if possible
+
+    val source: PGSimpleDataSource = new PGSimpleDataSource()
+    source.setPortNumber(config().port)
+    source.setServerName(config().host)
+    source.setDatabaseName(config().schema)
+    source.setUser(config().user)
+    source.setPassword(config().password)
+    config().useSsl match {
+      case PGUseSsl(sslfactory, sslfactoryarg) =>
+        source.setSsl(true)
+        sslfactory.foreach {f => source.setSslfactory(f)}
+        sslfactoryarg.foreach {f => source.setSslFactoryArg(f)}
+      case PGNoSsl() =>
+    }
+    dataSourceProperty := source
+  }
+
+  override protected def columnPropertiesSQL(container: ColumnPropertyContainer): List[String] = {
+    val b = ListBuffer.empty[String]
+    if (!container.isOptional && !container.has(Polymorphic)) {
+      b.append("NOT NULL")
+    }
+    if (container.has(Unique)) {
+      b.append("UNIQUE")
+    }
+    b.toList
+  }
+
+  override protected def columnSQLType(create: CreateColumn[_]) =
+    if (create.has(AutoIncrement)) {
+      "SERIAL"
+    } else if (create.dataType == doubleDataType) {
+      "DOUBLE PRECISION"
+//    } else if (create.dataType == byteArrayDataType) { //Not sure if this isn't tested or works without?
+//      "BYTEA"
+    } else if (create.dataType.isInstanceOf[ObjectSerializationConverter[_]]) {
+      "BYTEA"
+    } else if (create.dataType == blobDataType) {
+      "BYTEA"
+    } else {
+      super.columnSQLType(create)
+    }
+
+  override def jdbcTables = {
+    val s = session
+    val meta = s.connection.getMetaData
+    val results = meta.getTables(null, "public", "%", null)
+    try {
+      new ResultSetIterator(results).map(_.getString("TABLE_NAME")).toSet
+    } finally {
+      results.close()
+    }
+  }
+
+  override def jdbcColumns(tableName: String) = {
+    val s = session
+    val meta = s.connection.getMetaData
+    val results = meta.getColumns(null, "public", tableName, null)
+    try {
+      new ResultSetIterator(results).map(_.getString("COLUMN_NAME")).toSet
+    } finally {
+      results.close()
+    }
+  }
+
+  override def doesTableExist(name: String) = {
+    val s = session
+    val meta = s.connection.getMetaData
+    val results = meta.getTables(null, "public", name.toLowerCase, null)
+    try {
+      results.next()
+    } finally {
+      results.close()
+    }
+  }
+
+  override def condition2String(condition: Condition, args: ListBuffer[DataTyped[_]]): String = condition match {
+    case c: RegexCondition[_] => {
+      args += StringDataType.typed(c.regex.toString())
+      s"${c.column.longName} ${if (c.not) "!~ " else ""}~ ?"
+    }
+    case _ => super.condition2String(condition, args)
+  }
+}

--- a/postgresql/src/test/scala/org/scalarelational/postgresql/TableSpec.scala
+++ b/postgresql/src/test/scala/org/scalarelational/postgresql/TableSpec.scala
@@ -1,0 +1,19 @@
+package org.scalarelational.postgresql
+
+import org.scalarelational.extra.HikariSupport
+import org.scalarelational.{AbstractSpecialTypesDatastore, AbstractTableSpec, AbstractTestCrossReferenceDatastore, AbstractTestDatastore}
+
+import scala.language.postfixOps
+
+/**
+ * @author Robert Djubek <envy1988@gmail.com>
+ */
+class TableSpec extends AbstractTableSpec {
+  override def testDatastore = TestDatastore
+  override def specialTypes = SpecialTypesDatastore
+  override def testCrossReference = TestCrossReferenceDatastore
+}
+
+object TestDatastore extends PostgreSQLDatastore(PGConfig("localhost", "tablespec", "travis", "pa")) with AbstractTestDatastore with HikariSupport
+object TestCrossReferenceDatastore extends PostgreSQLDatastore(PGConfig("localhost", "cross_reference", "travis", "pa")) with AbstractTestCrossReferenceDatastore
+object SpecialTypesDatastore extends PostgreSQLDatastore(PGConfig("localhost", "special_types", "travis", "pa")) with AbstractSpecialTypesDatastore

--- a/postgresql/src/test/scala/org/scalarelational/postgresql/TableSpec.scala
+++ b/postgresql/src/test/scala/org/scalarelational/postgresql/TableSpec.scala
@@ -14,6 +14,6 @@ class TableSpec extends AbstractTableSpec {
   override def testCrossReference = TestCrossReferenceDatastore
 }
 
-object TestDatastore extends PostgreSQLDatastore(PGConfig("localhost", "tablespec", "travis", "pa")) with AbstractTestDatastore with HikariSupport
-object TestCrossReferenceDatastore extends PostgreSQLDatastore(PGConfig("localhost", "cross_reference", "travis", "pa")) with AbstractTestCrossReferenceDatastore
-object SpecialTypesDatastore extends PostgreSQLDatastore(PGConfig("localhost", "special_types", "travis", "pa")) with AbstractSpecialTypesDatastore
+object TestDatastore extends PostgreSQLDatastore(PostgreSQL.Config("localhost", "tablespec", "travis", "pa")) with AbstractTestDatastore with HikariSupport
+object TestCrossReferenceDatastore extends PostgreSQLDatastore(PostgreSQL.Config("localhost", "cross_reference", "travis", "pa")) with AbstractTestCrossReferenceDatastore
+object SpecialTypesDatastore extends PostgreSQLDatastore(PostgreSQL.Config("localhost", "special_types", "travis", "pa")) with AbstractSpecialTypesDatastore

--- a/postgresql/src/test/scala/org/scalarelational/postgresql/TableSslSpec.scala
+++ b/postgresql/src/test/scala/org/scalarelational/postgresql/TableSslSpec.scala
@@ -1,0 +1,23 @@
+package org.scalarelational.postgresql
+
+import org.scalarelational.extra.HikariSupport
+import org.scalarelational.{AbstractSpecialTypesDatastore, AbstractTableSpec, AbstractTestCrossReferenceDatastore, AbstractTestDatastore}
+
+import scala.language.postfixOps
+
+/**
+ * @author Robert Djubek <envy1988@gmail.com>
+ */
+case object Port {
+  val p: Int = 5432
+}
+
+class TableSslSpec extends AbstractTableSpec {
+  override def testDatastore = TestDatastoreSsl
+  override def specialTypes = SpecialTypesDatastoreSsl
+  override def testCrossReference = TestCrossReferenceDatastoreSsl
+}
+
+object TestDatastoreSsl extends PostgreSQLDatastore(PGConfig("localhost", "tablespec", "travis", "pa", Port.p, PGUseSsl(sslfactory = Some("org.postgresql.ssl.NonValidatingFactory")))) with AbstractTestDatastore with HikariSupport
+object TestCrossReferenceDatastoreSsl extends PostgreSQLDatastore(PGConfig("localhost", "cross_reference", "travis", "pa", useSsl = PGUseSsl(sslfactory = Some("org.postgresql.ssl.NonValidatingFactory")))) with AbstractTestCrossReferenceDatastore
+object SpecialTypesDatastoreSsl extends PostgreSQLDatastore(PGConfig("localhost", "special_types", "travis", "pa", useSsl = PGUseSsl(sslfactory = Some("org.postgresql.ssl.NonValidatingFactory")))) with AbstractSpecialTypesDatastore

--- a/postgresql/src/test/scala/org/scalarelational/postgresql/TableSslSpec.scala
+++ b/postgresql/src/test/scala/org/scalarelational/postgresql/TableSslSpec.scala
@@ -8,16 +8,12 @@ import scala.language.postfixOps
 /**
  * @author Robert Djubek <envy1988@gmail.com>
  */
-case object Port {
-  val p: Int = 5432
-}
-
 class TableSslSpec extends AbstractTableSpec {
   override def testDatastore = TestDatastoreSsl
   override def specialTypes = SpecialTypesDatastoreSsl
   override def testCrossReference = TestCrossReferenceDatastoreSsl
 }
 
-object TestDatastoreSsl extends PostgreSQLDatastore(PGConfig("localhost", "tablespec", "travis", "pa", Port.p, PGUseSsl(sslfactory = Some("org.postgresql.ssl.NonValidatingFactory")))) with AbstractTestDatastore with HikariSupport
-object TestCrossReferenceDatastoreSsl extends PostgreSQLDatastore(PGConfig("localhost", "cross_reference", "travis", "pa", useSsl = PGUseSsl(sslfactory = Some("org.postgresql.ssl.NonValidatingFactory")))) with AbstractTestCrossReferenceDatastore
-object SpecialTypesDatastoreSsl extends PostgreSQLDatastore(PGConfig("localhost", "special_types", "travis", "pa", useSsl = PGUseSsl(sslfactory = Some("org.postgresql.ssl.NonValidatingFactory")))) with AbstractSpecialTypesDatastore
+object TestDatastoreSsl extends PostgreSQLDatastore(PostgreSQL.Config("localhost", "tablespec", "travis", "pa", ssl = Some(PostgreSQL.SSL(sslFactory = Some("org.postgresql.ssl.NonValidatingFactory"))))) with AbstractTestDatastore with HikariSupport
+object TestCrossReferenceDatastoreSsl extends PostgreSQLDatastore(PostgreSQL.Config("localhost", "cross_reference", "travis", "pa", ssl = Some(PostgreSQL.SSL(sslFactory = Some("org.postgresql.ssl.NonValidatingFactory"))))) with AbstractTestCrossReferenceDatastore
+object SpecialTypesDatastoreSsl extends PostgreSQLDatastore(PostgreSQL.Config("localhost", "special_types", "travis", "pa", ssl = Some(PostgreSQL.SSL(sslFactory = Some("org.postgresql.ssl.NonValidatingFactory"))))) with AbstractSpecialTypesDatastore


### PR DESCRIPTION
I have added two Spec files.

One tests using an SSL connection and does not run by default; SSL is disabled in default postgresql installations.
	You need to change configuration of postgresql as well as importing a keyfile into the java keystore (if you self sign) (or, as done in the tests, pass an sslfactory that does not validate with a CA)
	If those pre-reqs are met you can run the ssl test; pgssl:test

The second test is about as vanilla as it gets.

Both tests assume a user 'travis', password 'pa', and the databases 'tablespec', 'cross_reference', 'special_types' usable by 'travis' exists on localhost with postgresql running on default port (5432)

Most tests are working; 6 total fail.

1 I talked to darkfrog about. iirc, he thinks he has a fix.
2 are related to large objects not working in autocommit.
2 are false negatives; the followup tests checking for the result of the inserts prove they succeeded.
1 is for currently unsupported syntax that will be available in postgresql 9.5 for create unique indexes if not exist.