### PR TITLE
Query updates

### DIFF
--- a/core/src/main/scala/org/scalarelational/dsl/DSLSupport.scala
+++ b/core/src/main/scala/org/scalarelational/dsl/DSLSupport.scala
@@ -3,6 +3,7 @@ package org.scalarelational.dsl
 import org.scalarelational.SelectExpression
 import org.scalarelational.column.{Column, ColumnValue}
 import org.scalarelational.instruction._
+import org.scalarelational.instruction.query._
 import org.scalarelational.result.QueryResult
 import org.scalarelational.table.Table
 
@@ -15,30 +16,36 @@ trait DSLSupport {
   import DSLSupport._
 
   def select[E](e1: SelectExpression[E]) = {
-    Query[SelectExpression[E], E](e1, converter = singleValueConverter[E])
+    Query(SingleExpression(e1), converter = singleValueConverter[E])
   }
   def select[E1, E2](e1: SelectExpression[E1], e2: SelectExpression[E2]) = {
-    Query[(SelectExpression[E1], SelectExpression[E2]), (E1, E2)]((e1, e2), converter = tuple2Converter[E1, E2])
+    Query(TwoExpressions(e1, e2), converter = tuple2Converter[E1, E2])
   }
   def select[E1, E2, E3](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3]) = {
-    Query[(SelectExpression[E1], SelectExpression[E2], SelectExpression[E3]), (E1, E2, E3)]((e1, e2, e3), converter = tuple3Converter[E1, E2, E3])
+    Query(ThreeExpressions(e1, e2, e3), converter = tuple3Converter[E1, E2, E3])
   }
   def select[E1, E2, E3, E4](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4]) = {
-    Query[(SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4]), (E1, E2, E3, E4)]((e1, e2, e3, e4), converter = tuple4Converter[E1, E2, E3, E4])
+    Query(FourExpressions(e1, e2, e3, e4), converter = tuple4Converter[E1, E2, E3, E4])
   }
   def select[E1, E2, E3, E4, E5](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5]) = {
-    Query[(SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4], SelectExpression[E5]), (E1, E2, E3, E4, E5)]((e1, e2, e3, e4, e5), converter = tuple5Converter[E1, E2, E3, E4, E5])
+    Query(FiveExpressions(e1, e2, e3, e4, e5), converter = tuple5Converter[E1, E2, E3, E4, E5])
   }
   def select[E1, E2, E3, E4, E5, E6](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6]) = {
-    Query[(SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4], SelectExpression[E5], SelectExpression[E6]), (E1, E2, E3, E4, E5, E6)]((e1, e2, e3, e4, e5, e6), converter = tuple6Converter[E1, E2, E3, E4, E5, E6])
+    Query(SixExpressions(e1, e2, e3, e4, e5, e6), converter = tuple6Converter[E1, E2, E3, E4, E5, E6])
   }
   def select[E1, E2, E3, E4, E5, E6, E7](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6], e7: SelectExpression[E7]) = {
-    Query[(SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4], SelectExpression[E5], SelectExpression[E6], SelectExpression[E7]), (E1, E2, E3, E4, E5, E6, E7)]((e1, e2, e3, e4, e5, e6, e7), converter = tuple7Converter[E1, E2, E3, E4, E5, E6, E7])
+    Query(SevenExpressions(e1, e2, e3, e4, e5, e6, e7), converter = tuple7Converter[E1, E2, E3, E4, E5, E6, E7])
   }
   def select[E1, E2, E3, E4, E5, E6, E7, E8](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6], e7: SelectExpression[E7], e8: SelectExpression[E8]) = {
-    Query[(SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4], SelectExpression[E5], SelectExpression[E6], SelectExpression[E7], SelectExpression[E8]), (E1, E2, E3, E4, E5, E6, E7, E8)]((e1, e2, e3, e4, e5, e6, e7, e8), converter = tuple8Converter[E1, E2, E3, E4, E5, E6, E7, E8])
+    Query(EightExpressions(e1, e2, e3, e4, e5, e6, e7, e8), converter = tuple8Converter[E1, E2, E3, E4, E5, E6, E7, E8])
   }
-  def select(expressions: List[SelectExpression[_]]) = Query[Vector[SelectExpression[_]], QueryResult[_]](expressions.toVector, converter = DefaultConverter)
+  def select[E1, E2, E3, E4, E5, E6, E7, E8, E9](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6], e7: SelectExpression[E7], e8: SelectExpression[E8], e9: SelectExpression[E9]) = {
+    Query(NineExpressions(e1, e2, e3, e4, e5, e6, e7, e8, e9), converter = tuple9Converter[E1, E2, E3, E4, E5, E6, E7, E8, E9])
+  }
+  def select[E1, E2, E3, E4, E5, E6, E7, E8, E9, E10](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6], e7: SelectExpression[E7], e8: SelectExpression[E8], e9: SelectExpression[E9], e10: SelectExpression[E10]) = {
+    Query(TenExpressions(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10), converter = tuple10Converter[E1, E2, E3, E4, E5, E6, E7, E8, E9, E10])
+  }
+  def select(expressions: List[SelectExpression[_]]) = Query[Vector[SelectExpression[_]], QueryResult](VariableExpressions(expressions.toVector), converter = DefaultConverter)
   def insert(values: ColumnValue[_, _]*) = InsertSingle[Int](values.head.column.table, values, identity[Int])
   def insertInto(table: Table, values: Any*) = insert(values.zip(table.columns).map {
     case (value, column) => column.asInstanceOf[Column[Any, Any]](value)
@@ -52,29 +59,16 @@ trait DSLSupport {
 }
 
 object DSLSupport extends DSLSupport {
-  val DefaultConverter = (qr: QueryResult[_]) => qr
+  val DefaultConverter = (qr: QueryResult) => qr
 
-  def singleValueConverter[E] = (qr: QueryResult[E]) => qr.values.head.value.asInstanceOf[E]
-  implicit def vectorifySingleValue[E](t: SelectExpression[E]): Vector[SelectExpression[_]] = Vector(t)
-
-  def tuple2Converter[E1, E2] = (qr: QueryResult[(E1, E2)]) => qr.values.head.value.asInstanceOf[E1] -> qr.values(1).value.asInstanceOf[E2]
-  implicit def vectorifyTuple2[E1, E2](t: (SelectExpression[E1], SelectExpression[E2])): Vector[SelectExpression[_]] = Vector(t._1, t._2)
-
-  def tuple3Converter[E1, E2, E3] = (qr: QueryResult[(E1, E2, E3)]) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3])
-  implicit def vectorifyTuple3[E1, E2, E3](t: (SelectExpression[E1], SelectExpression[E2], SelectExpression[E3])): Vector[SelectExpression[_]] = Vector(t._1, t._2, t._3)
-
-  def tuple4Converter[E1, E2, E3, E4] = (qr: QueryResult[(E1, E2, E3, E4)]) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4])
-  implicit def vectorifyTuple4[E1, E2, E3, E4](t: (SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4])): Vector[SelectExpression[_]] = Vector(t._1, t._2, t._3, t._4)
-
-  def tuple5Converter[E1, E2, E3, E4, E5] = (qr: QueryResult[(E1, E2, E3, E4, E5)]) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5])
-  implicit def vectorifyTuple5[E1, E2, E3, E4, E5](t: (SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4], SelectExpression[E5])): Vector[SelectExpression[_]] = Vector(t._1, t._2, t._3, t._4, t._5)
-
-  def tuple6Converter[E1, E2, E3, E4, E5, E6] = (qr: QueryResult[(E1, E2, E3, E4, E5, E6)]) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5], qr.values(5).value.asInstanceOf[E6])
-  implicit def vectorifyTuple6[E1, E2, E3, E4, E5, E6](t: (SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4], SelectExpression[E5], SelectExpression[E6])): Vector[SelectExpression[_]] = Vector(t._1, t._2, t._3, t._4, t._5, t._6)
-
-  def tuple7Converter[E1, E2, E3, E4, E5, E6, E7] = (qr: QueryResult[(E1, E2, E3, E4, E5, E6, E7)]) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5], qr.values(5).value.asInstanceOf[E6], qr.values(6).value.asInstanceOf[E7])
-  implicit def vectorifyTuple7[E1, E2, E3, E4, E5, E6, E7](t: (SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4], SelectExpression[E5], SelectExpression[E6], SelectExpression[E7])): Vector[SelectExpression[_]] = Vector(t._1, t._2, t._3, t._4, t._5, t._6, t._7)
-
-  def tuple8Converter[E1, E2, E3, E4, E5, E6, E7, E8] = (qr: QueryResult[(E1, E2, E3, E4, E5, E6, E7, E8)]) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5], qr.values(5).value.asInstanceOf[E6], qr.values(6).value.asInstanceOf[E7], qr.values(7).value.asInstanceOf[E8])
-  implicit def vectorifyTuple8[E1, E2, E3, E4, E5, E6, E7, E8](t: (SelectExpression[E1], SelectExpression[E2], SelectExpression[E3], SelectExpression[E4], SelectExpression[E5], SelectExpression[E6], SelectExpression[E7], SelectExpression[E8])): Vector[SelectExpression[_]] = Vector(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
+  def singleValueConverter[E] = (qr: QueryResult) => qr.values.head.value.asInstanceOf[E]
+  def tuple2Converter[E1, E2] = (qr: QueryResult) => qr.values.head.value.asInstanceOf[E1] -> qr.values(1).value.asInstanceOf[E2]
+  def tuple3Converter[E1, E2, E3] = (qr: QueryResult) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3])
+  def tuple4Converter[E1, E2, E3, E4] = (qr: QueryResult) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4])
+  def tuple5Converter[E1, E2, E3, E4, E5] = (qr: QueryResult) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5])
+  def tuple6Converter[E1, E2, E3, E4, E5, E6] = (qr: QueryResult) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5], qr.values(5).value.asInstanceOf[E6])
+  def tuple7Converter[E1, E2, E3, E4, E5, E6, E7] = (qr: QueryResult) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5], qr.values(5).value.asInstanceOf[E6], qr.values(6).value.asInstanceOf[E7])
+  def tuple8Converter[E1, E2, E3, E4, E5, E6, E7, E8] = (qr: QueryResult) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5], qr.values(5).value.asInstanceOf[E6], qr.values(6).value.asInstanceOf[E7], qr.values(7).value.asInstanceOf[E8])
+  def tuple9Converter[E1, E2, E3, E4, E5, E6, E7, E8, E9] = (qr: QueryResult) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5], qr.values(5).value.asInstanceOf[E6], qr.values(6).value.asInstanceOf[E7], qr.values(7).value.asInstanceOf[E8], qr.values(8).value.asInstanceOf[E9])
+  def tuple10Converter[E1, E2, E3, E4, E5, E6, E7, E8, E9, E10] = (qr: QueryResult) => (qr.values.head.value.asInstanceOf[E1], qr.values(1).value.asInstanceOf[E2], qr.values(2).value.asInstanceOf[E3], qr.values(3).value.asInstanceOf[E4], qr.values(4).value.asInstanceOf[E5], qr.values(5).value.asInstanceOf[E6], qr.values(6).value.asInstanceOf[E7], qr.values(7).value.asInstanceOf[E8], qr.values(8).value.asInstanceOf[E9], qr.values(9).value.asInstanceOf[E10])
 }

--- a/core/src/main/scala/org/scalarelational/dsl/DSLSupport.scala
+++ b/core/src/main/scala/org/scalarelational/dsl/DSLSupport.scala
@@ -16,36 +16,36 @@ trait DSLSupport {
   import DSLSupport._
 
   def select[E](e1: SelectExpression[E]) = {
-    Query(SingleExpression(e1), converter = singleValueConverter[E])
+    SelectQueryPart(SingleExpression(e1), singleValueConverter[E])
   }
   def select[E1, E2](e1: SelectExpression[E1], e2: SelectExpression[E2]) = {
-    Query(TwoExpressions(e1, e2), converter = tuple2Converter[E1, E2])
+    SelectQueryPart(TwoExpressions(e1, e2), tuple2Converter[E1, E2])
   }
   def select[E1, E2, E3](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3]) = {
-    Query(ThreeExpressions(e1, e2, e3), converter = tuple3Converter[E1, E2, E3])
+    SelectQueryPart(ThreeExpressions(e1, e2, e3), tuple3Converter[E1, E2, E3])
   }
   def select[E1, E2, E3, E4](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4]) = {
-    Query(FourExpressions(e1, e2, e3, e4), converter = tuple4Converter[E1, E2, E3, E4])
+    SelectQueryPart(FourExpressions(e1, e2, e3, e4), tuple4Converter[E1, E2, E3, E4])
   }
   def select[E1, E2, E3, E4, E5](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5]) = {
-    Query(FiveExpressions(e1, e2, e3, e4, e5), converter = tuple5Converter[E1, E2, E3, E4, E5])
+    SelectQueryPart(FiveExpressions(e1, e2, e3, e4, e5), tuple5Converter[E1, E2, E3, E4, E5])
   }
   def select[E1, E2, E3, E4, E5, E6](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6]) = {
-    Query(SixExpressions(e1, e2, e3, e4, e5, e6), converter = tuple6Converter[E1, E2, E3, E4, E5, E6])
+    SelectQueryPart(SixExpressions(e1, e2, e3, e4, e5, e6), tuple6Converter[E1, E2, E3, E4, E5, E6])
   }
   def select[E1, E2, E3, E4, E5, E6, E7](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6], e7: SelectExpression[E7]) = {
-    Query(SevenExpressions(e1, e2, e3, e4, e5, e6, e7), converter = tuple7Converter[E1, E2, E3, E4, E5, E6, E7])
+    SelectQueryPart(SevenExpressions(e1, e2, e3, e4, e5, e6, e7), tuple7Converter[E1, E2, E3, E4, E5, E6, E7])
   }
   def select[E1, E2, E3, E4, E5, E6, E7, E8](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6], e7: SelectExpression[E7], e8: SelectExpression[E8]) = {
-    Query(EightExpressions(e1, e2, e3, e4, e5, e6, e7, e8), converter = tuple8Converter[E1, E2, E3, E4, E5, E6, E7, E8])
+    SelectQueryPart(EightExpressions(e1, e2, e3, e4, e5, e6, e7, e8), tuple8Converter[E1, E2, E3, E4, E5, E6, E7, E8])
   }
   def select[E1, E2, E3, E4, E5, E6, E7, E8, E9](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6], e7: SelectExpression[E7], e8: SelectExpression[E8], e9: SelectExpression[E9]) = {
-    Query(NineExpressions(e1, e2, e3, e4, e5, e6, e7, e8, e9), converter = tuple9Converter[E1, E2, E3, E4, E5, E6, E7, E8, E9])
+    SelectQueryPart(NineExpressions(e1, e2, e3, e4, e5, e6, e7, e8, e9), tuple9Converter[E1, E2, E3, E4, E5, E6, E7, E8, E9])
   }
   def select[E1, E2, E3, E4, E5, E6, E7, E8, E9, E10](e1: SelectExpression[E1], e2: SelectExpression[E2], e3: SelectExpression[E3], e4: SelectExpression[E4], e5: SelectExpression[E5], e6: SelectExpression[E6], e7: SelectExpression[E7], e8: SelectExpression[E8], e9: SelectExpression[E9], e10: SelectExpression[E10]) = {
-    Query(TenExpressions(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10), converter = tuple10Converter[E1, E2, E3, E4, E5, E6, E7, E8, E9, E10])
+    SelectQueryPart(TenExpressions(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10), tuple10Converter[E1, E2, E3, E4, E5, E6, E7, E8, E9, E10])
   }
-  def select(expressions: List[SelectExpression[_]]) = Query[Vector[SelectExpression[_]], QueryResult](VariableExpressions(expressions.toVector), converter = DefaultConverter)
+  def select(expressions: List[SelectExpression[_]]) = SelectQueryPart[Vector[SelectExpression[_]], QueryResult](VariableExpressions(expressions.toVector), DefaultConverter)
   def insert(values: ColumnValue[_, _]*) = InsertSingle[Int](values.head.column.table, values, identity[Int])
   def insertInto(table: Table, values: Any*) = insert(values.zip(table.columns).map {
     case (value, column) => column.asInstanceOf[Column[Any, Any]](value)

--- a/core/src/main/scala/org/scalarelational/extra/PersistentProperties.scala
+++ b/core/src/main/scala/org/scalarelational/extra/PersistentProperties.scala
@@ -24,7 +24,7 @@ trait PersistentProperties extends Datastore {
   object persistence {
     def get(name: String): Option[String] = {
       val query = select(persistentProperties.value) from persistentProperties where persistentProperties.key === name
-      query.result.converted.headOption
+      query.converted.headOption
     }
 
     def apply(name: String): String = {

--- a/core/src/main/scala/org/scalarelational/instruction/Join.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/Join.scala
@@ -10,7 +10,7 @@ case class Join(joinable: Joinable, joinType: JoinType = JoinType.Join, conditio
 
 // Used for DSL before the actual Join instance is created
 case class PartialJoin[E, R](query: Query[E, R], joinable: Joinable, joinType: JoinType) {
-  def on(condition: Condition) = query.copy[E, R](joins = (Join(joinable, joinType, condition) :: query.joins.reverse).reverse)(query.vectorify)
+  def on(condition: Condition) = query.copy[E, R](joins = (Join(joinable, joinType, condition) :: query.joins.reverse).reverse)
 }
 
 sealed abstract class JoinType extends EnumEntry

--- a/core/src/main/scala/org/scalarelational/instruction/Query.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/Query.scala
@@ -3,7 +3,7 @@ package org.scalarelational.instruction
 import org.powerscala.reflect._
 import org.scalarelational._
 import org.scalarelational.column.{ColumnAlias, ColumnLike}
-import org.scalarelational.instruction.query.SelectExpressions
+import org.scalarelational.instruction.query.{JoinSupport, SelectExpressions}
 import org.scalarelational.op.Condition
 import org.scalarelational.result.{EnhancedIterator, QueryResult, QueryResultsIterator}
 import org.scalarelational.table.Table
@@ -22,15 +22,12 @@ case class Query[Types, Result](expressions: SelectExpressions[Types],
                                 resultLimit: Int = -1,
                                 resultOffset: Int = -1,
                                 converter: QueryResult => Result,
-                                alias: Option[String] = None) extends WhereSupport[Query[Types, Result]] with Joinable {
+                                alias: Option[String] = None) extends WhereSupport[Query[Types, Result]]
+                                                              with Joinable
+                                                              with JoinSupport[Types, Result] {
   def apply[T, S](column: ColumnLike[T, S]) = ColumnAlias[T, S](column, alias, None, None)
 
   def where(condition: Condition) = copy[Types, Result](whereCondition = condition)
-
-  def join(joinable: Joinable, joinType: JoinType = JoinType.Join) = PartialJoin[Types, Result](this, joinable, joinType)
-  def innerJoin(joinable: Joinable) = join(joinable, joinType = JoinType.Inner)
-  def leftJoin(joinable: Joinable) = join(joinable, joinType = JoinType.Left)
-  def leftOuterJoin(joinable: Joinable) = join(joinable, joinType = JoinType.LeftOuter)
 
   def limit(value: Int) = copy[Types, Result](resultLimit = value)
   def offset(value: Int) = copy[Types, Result](resultOffset = value)

--- a/core/src/main/scala/org/scalarelational/instruction/Query.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/Query.scala
@@ -25,7 +25,6 @@ case class Query[Types, Result](expressions: SelectExpressions[Types],
                                 alias: Option[String] = None) extends WhereSupport[Query[Types, Result]] with Joinable {
   def apply[T, S](column: ColumnLike[T, S]) = ColumnAlias[T, S](column, alias, None, None)
 
-  def from(table: Table) = copy[Types, Result](table = table)
   def where(condition: Condition) = copy[Types, Result](whereCondition = condition)
 
   def join(joinable: Joinable, joinType: JoinType = JoinType.Join) = PartialJoin[Types, Result](this, joinable, joinType)

--- a/core/src/main/scala/org/scalarelational/instruction/Query.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/Query.scala
@@ -5,7 +5,7 @@ import org.scalarelational._
 import org.scalarelational.column.{ColumnAlias, ColumnLike}
 import org.scalarelational.instruction.query.SelectExpressions
 import org.scalarelational.op.Condition
-import org.scalarelational.result.{QueryResult, QueryResultsIterator}
+import org.scalarelational.result.{EnhancedIterator, QueryResult, QueryResultsIterator}
 import org.scalarelational.table.Table
 
 import scala.language.existentials
@@ -45,7 +45,7 @@ case class Query[Types, Result](expressions: SelectExpressions[Types],
   def convert[NewResult](converter: QueryResult => NewResult) = copy[Types, NewResult](converter = converter)
 
   def result = new QueryResultsIterator(table.datastore.exec(this), this)
-  def converted = result.converted
+  def converted = new EnhancedIterator[Result](result.map(qr => converter(qr)))
   def async = table.datastore.async {
     result
   }

--- a/core/src/main/scala/org/scalarelational/instruction/Query.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/Query.scala
@@ -3,7 +3,7 @@ package org.scalarelational.instruction
 import org.powerscala.reflect._
 import org.scalarelational._
 import org.scalarelational.column.{ColumnAlias, ColumnLike}
-import org.scalarelational.dsl.DSLSupport
+import org.scalarelational.instruction.query.SelectExpressions
 import org.scalarelational.op.Condition
 import org.scalarelational.result.{QueryResult, QueryResultsIterator}
 import org.scalarelational.table.Table
@@ -13,53 +13,44 @@ import scala.language.existentials
 /**
  * @author Matt Hicks <matt@outr.com>
  */
-case class Query[Expressions, Result](expressions: Expressions,
-                                      table: Table = null,
-                                      joins: List[Join] = Nil,
-                                      whereCondition: Condition = null,
-                                      grouping: List[SelectExpression[_]] = Nil,
-                                      ordering: List[OrderBy[_]] = Nil,
-                                      resultLimit: Int = -1,
-                                      resultOffset: Int = -1,
-                                      converter: QueryResult[Result] => Result,
-                                      alias: Option[String] = None)
-                                     (implicit val vectorify: Expressions => Vector[SelectExpression[_]]) extends WhereSupport[Query[Expressions, Result]] with Joinable {
-  lazy val asVector = vectorify(expressions)
-
+case class Query[Types, Result](expressions: SelectExpressions[Types],
+                                table: Table = null,
+                                joins: List[Join] = Nil,
+                                whereCondition: Condition = null,
+                                grouping: List[SelectExpression[_]] = Nil,
+                                ordering: List[OrderBy[_]] = Nil,
+                                resultLimit: Int = -1,
+                                resultOffset: Int = -1,
+                                converter: QueryResult => Result,
+                                alias: Option[String] = None) extends WhereSupport[Query[Types, Result]] with Joinable {
   def apply[T, S](column: ColumnLike[T, S]) = ColumnAlias[T, S](column, alias, None, None)
 
-  def fields(expressions: SelectExpression[_]*) = copy[Vector[SelectExpression[_]], QueryResult[_]](expressions = asVector ++ expressions, converter = DSLSupport.DefaultConverter)
-  def fields(expressions: Vector[SelectExpression[_]]) = copy[Vector[SelectExpression[_]], QueryResult[_]](expressions = this.expressions ++ expressions, converter = DSLSupport.DefaultConverter)
-  def withoutField(expression: SelectExpression[_]) = copy[Vector[SelectExpression[_]], QueryResult[_]](expressions = expressions.filterNot(se => se == expression), converter = DSLSupport.DefaultConverter)
-  def clearFields() = copy[Vector[SelectExpression[_]], QueryResult[_]](expressions = Vector.empty, converter = DSLSupport.DefaultConverter)
+  def from(table: Table) = copy[Types, Result](table = table)
+  def where(condition: Condition) = copy[Types, Result](whereCondition = condition)
 
-  def from(table: Table) = copy[Expressions, Result](table = table)
-  def where(condition: Condition) = copy[Expressions, Result](whereCondition = condition)
-
-  def join(joinable: Joinable, joinType: JoinType = JoinType.Join) = PartialJoin[Expressions, Result](this, joinable, joinType)
+  def join(joinable: Joinable, joinType: JoinType = JoinType.Join) = PartialJoin[Types, Result](this, joinable, joinType)
   def innerJoin(joinable: Joinable) = join(joinable, joinType = JoinType.Inner)
   def leftJoin(joinable: Joinable) = join(joinable, joinType = JoinType.Left)
   def leftOuterJoin(joinable: Joinable) = join(joinable, joinType = JoinType.LeftOuter)
 
-  def limit(value: Int) = copy[Expressions, Result](resultLimit = value)
-  def offset(value: Int) = copy[Expressions, Result](resultOffset = value)
+  def limit(value: Int) = copy[Types, Result](resultLimit = value)
+  def offset(value: Int) = copy[Types, Result](resultOffset = value)
 
-  def groupBy(expressions: SelectExpression[_]*) = copy[Expressions, Result](grouping = grouping ::: expressions.toList)
-  def orderBy(entries: OrderBy[_]*) = copy[Expressions, Result](ordering = entries.toList ::: ordering)
+  def groupBy(expressions: SelectExpression[_]*) = copy[Types, Result](grouping = grouping ::: expressions.toList)
+  def orderBy(entries: OrderBy[_]*) = copy[Types, Result](ordering = entries.toList ::: ordering)
 
   def as(alias: String) = copy(alias = Option(alias))
 
-  def convert[NewResult](converter: QueryResult[NewResult] => NewResult) = copy[Expressions, NewResult](converter = converter)
-  def map[NewResult](converter: Result => NewResult) = {
-    copy[Expressions, NewResult](converter = (qr: QueryResult[NewResult]) => converter(this.converter(qr.asInstanceOf[QueryResult[Result]])))
-  }
+  def map[NewResult](converter: Result => NewResult) = copy[Types, NewResult](converter = this.converter.andThen(converter))
+  def convert[NewResult](converter: QueryResult => NewResult) = copy[Types, NewResult](converter = converter)
 
   def result = new QueryResultsIterator(table.datastore.exec(this), this)
+  def converted = result.converted
   def async = table.datastore.async {
     result
   }
 
-  def asCase[R](classForRow: QueryResult[R] => Class[_])(implicit manifest: Manifest[R]): Query[Expressions, R] = {
+  def asCase[R](classForRow: QueryResult => Class[_])(implicit manifest: Manifest[R]): Query[Types, R] = {
     convert[R] { r =>
       val clazz = classForRow(r)
       clazz.create[R](r.toFieldMap)
@@ -67,4 +58,4 @@ case class Query[Expressions, Result](expressions: Expressions,
   }
 }
 
-trait ResultConverter[Result] extends ((QueryResult[Result]) => Result)
+trait ResultConverter[Result] extends (QueryResult => Result)

--- a/core/src/main/scala/org/scalarelational/instruction/WhereSupport.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/WhereSupport.scala
@@ -10,6 +10,14 @@ trait WhereSupport[+S <: WhereSupport[S]] extends SQLStatement {
 
   def where(condition: Condition): S
 
-  def and(condition: Condition) = where(Conditions(List(whereCondition, condition), ConnectType.And))
-  def or(condition: Condition) = where(Conditions(List(whereCondition, condition), ConnectType.Or))
+  def and(condition: Condition) = if (whereCondition != null) {
+    where(Conditions(List(whereCondition, condition), ConnectType.And))
+  } else {
+    where(condition)
+  }
+  def or(condition: Condition) = if (whereCondition != null) {
+    where(Conditions(List(whereCondition, condition), ConnectType.Or))
+  } else {
+    where(condition)
+  }
 }

--- a/core/src/main/scala/org/scalarelational/instruction/query/JoinSupport.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/query/JoinSupport.scala
@@ -1,0 +1,12 @@
+package org.scalarelational.instruction.query
+
+import org.scalarelational.instruction.{Query, PartialJoin, JoinType, Joinable}
+
+trait JoinSupport[Types, Result] {
+  this: Query[Types, Result] =>
+
+  def join(joinable: Joinable, joinType: JoinType = JoinType.Join) = PartialJoin[Types, Result](this, joinable, joinType)
+  def innerJoin(joinable: Joinable) = join(joinable, joinType = JoinType.Inner)
+  def leftJoin(joinable: Joinable) = join(joinable, joinType = JoinType.Left)
+  def leftOuterJoin(joinable: Joinable) = join(joinable, joinType = JoinType.LeftOuter)
+}

--- a/core/src/main/scala/org/scalarelational/instruction/query/SelectExpressions.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/query/SelectExpressions.scala
@@ -1,0 +1,49 @@
+package org.scalarelational.instruction.query
+
+import org.scalarelational.{SelectExpression => SE}
+
+trait SelectExpressions[T] {
+  def vector: Vector[SE[_]]
+}
+
+case class SingleExpression[T](e: SE[T]) extends SelectExpressions[T] {
+  lazy val vector = Vector(e)
+}
+
+case class TwoExpressions[T1, T2](e1: SE[T1], e2: SE[T2]) extends SelectExpressions[(T1, T2)] {
+  lazy val vector = Vector(e1, e2)
+}
+
+case class ThreeExpressions[T1, T2, T3](e1: SE[T1], e2: SE[T2], e3: SE[T3]) extends SelectExpressions[(T1, T2, T3)] {
+  lazy val vector = Vector(e1, e2, e3)
+}
+
+case class FourExpressions[T1, T2, T3, T4](e1: SE[T1], e2: SE[T2], e3: SE[T3], e4: SE[T4]) extends SelectExpressions[(T1, T2, T3, T4)] {
+  lazy val vector = Vector(e1, e2, e3, e4)
+}
+
+case class FiveExpressions[T1, T2, T3, T4, T5](e1: SE[T1], e2: SE[T2], e3: SE[T3], e4: SE[T4], e5: SE[T5]) extends SelectExpressions[(T1, T2, T3, T4, T5)] {
+  lazy val vector = Vector(e1, e2, e3, e4, e5)
+}
+
+case class SixExpressions[T1, T2, T3, T4, T5, T6](e1: SE[T1], e2: SE[T2], e3: SE[T3], e4: SE[T4], e5: SE[T5], e6: SE[T6]) extends SelectExpressions[(T1, T2, T3, T4, T5, T6)] {
+  lazy val vector = Vector(e1, e2, e3, e4, e5, e6)
+}
+
+case class SevenExpressions[T1, T2, T3, T4, T5, T6, T7](e1: SE[T1], e2: SE[T2], e3: SE[T3], e4: SE[T4], e5: SE[T5], e6: SE[T6], e7: SE[T7]) extends SelectExpressions[(T1, T2, T3, T4, T5, T6, T7)] {
+  lazy val vector = Vector(e1, e2, e3, e4, e5, e6, e7)
+}
+
+case class EightExpressions[T1, T2, T3, T4, T5, T6, T7, T8](e1: SE[T1], e2: SE[T2], e3: SE[T3], e4: SE[T4], e5: SE[T5], e6: SE[T6], e7: SE[T7], e8: SE[T8]) extends SelectExpressions[(T1, T2, T3, T4, T5, T6, T7, T8)] {
+  lazy val vector = Vector(e1, e2, e3, e4, e5, e6, e7, e8)
+}
+
+case class NineExpressions[T1, T2, T3, T4, T5, T6, T7, T8, T9](e1: SE[T1], e2: SE[T2], e3: SE[T3], e4: SE[T4], e5: SE[T5], e6: SE[T6], e7: SE[T7], e8: SE[T8], e9: SE[T9]) extends SelectExpressions[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] {
+  lazy val vector = Vector(e1, e2, e3, e4, e5, e6, e7, e8, e9)
+}
+
+case class TenExpressions[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](e1: SE[T1], e2: SE[T2], e3: SE[T3], e4: SE[T4], e5: SE[T5], e6: SE[T6], e7: SE[T7], e8: SE[T8], e9: SE[T9], e10: SE[T10]) extends SelectExpressions[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] {
+  lazy val vector = Vector(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10)
+}
+
+case class VariableExpressions[T](vector: Vector[SE[_]]) extends SelectExpressions[T]

--- a/core/src/main/scala/org/scalarelational/instruction/query/SelectQueryPart.scala
+++ b/core/src/main/scala/org/scalarelational/instruction/query/SelectQueryPart.scala
@@ -1,0 +1,10 @@
+package org.scalarelational.instruction.query
+
+import org.scalarelational.instruction.Query
+import org.scalarelational.result.QueryResult
+import org.scalarelational.table.Table
+
+case class SelectQueryPart[Types, Result](expressions: SelectExpressions[Types],
+                                          converter: QueryResult => Result) {
+  def from(table: Table) = Query[Types, Result](expressions, table, converter = converter)
+}

--- a/core/src/main/scala/org/scalarelational/model/SQLDatastore.scala
+++ b/core/src/main/scala/org/scalarelational/model/SQLDatastore.scala
@@ -37,7 +37,7 @@ abstract class SQLDatastore protected() extends Datastore with BasicDDLSupport {
   }
 
   def describe[E, R](query: Query[E, R]) = {
-    val columns = query.asVector.map(expression2SQL).mkString(", ")
+    val columns = query.expressions.vector.map(expression2SQL).mkString(", ")
 
     var args = List.empty[TypedValue[_, _]]
 

--- a/core/src/main/scala/org/scalarelational/result/QueryResult.scala
+++ b/core/src/main/scala/org/scalarelational/result/QueryResult.scala
@@ -10,11 +10,7 @@ import scala.language.existentials
 /**
  * @author Matt Hicks <matt@outr.com>
  */
-case class QueryResult[Result](table: Table, values: Vector[ExpressionValue[_]], converter: QueryResult[Result] => Result) {
-  lazy val converted = converter(this)
-
-  def apply() = converted
-
+case class QueryResult(table: Table, values: Vector[ExpressionValue[_]]) {
   def get[T, S](column: Column[T, S]) = values.collectFirst {
     case cv: ColumnValue[_, _] if cv.column == column => Option(cv.value.asInstanceOf[T])
   }.flatten

--- a/core/src/main/scala/org/scalarelational/result/QueryResultsIterator.scala
+++ b/core/src/main/scala/org/scalarelational/result/QueryResultsIterator.scala
@@ -19,8 +19,6 @@ class QueryResultsIterator[E, R](rs: ResultSet, val query: Query[E, R]) extends 
   private val NothingLeft = 2
   private var nextStatus = NextNotCalled
 
-  def converted = new EnhancedIterator[R](map(qr => query.converter(qr)))
-
   def hasNext = synchronized {
     if (nextStatus == NextNotCalled) {
       nextStatus = if (rs.next()) HasNext else NothingLeft

--- a/core/src/main/scala/org/scalarelational/result/QueryResultsIterator.scala
+++ b/core/src/main/scala/org/scalarelational/result/QueryResultsIterator.scala
@@ -13,13 +13,13 @@ import org.scalarelational.{ExpressionValue, SelectExpression}
 /**
  * @author Matt Hicks <matt@outr.com>
  */
-class QueryResultsIterator[E, R](rs: ResultSet, val query: Query[E, R]) extends Iterator[QueryResult[R]] {
+class QueryResultsIterator[E, R](rs: ResultSet, val query: Query[E, R]) extends Iterator[QueryResult] {
   private val NextNotCalled = 0
   private val HasNext = 1
   private val NothingLeft = 2
   private var nextStatus = NextNotCalled
 
-  def converted = new EnhancedIterator[R](map(_.converted))
+  def converted = new EnhancedIterator[R](map(qr => query.converter(qr)))
 
   def hasNext = synchronized {
     if (nextStatus == NextNotCalled) {
@@ -30,10 +30,10 @@ class QueryResultsIterator[E, R](rs: ResultSet, val query: Query[E, R]) extends 
 
   def nextOption() = if (hasNext) {
     try {
-      val values = query.asVector.zipWithIndex.map {
+      val values = query.expressions.vector.zipWithIndex.map {
         case (expression, index) => valueFromExpressions(expression, index)
       }
-      Some(QueryResult[R](query.table, values, query.converter))
+      Some(QueryResult(query.table, values))
     } finally {
       synchronized {
         nextStatus = NextNotCalled

--- a/core/src/test/scala/org/scalarelational/AbstractTableSpec.scala
+++ b/core/src/test/scala/org/scalarelational/AbstractTableSpec.scala
@@ -8,6 +8,7 @@ import org.scalarelational.column.ColumnLike
 import org.scalarelational.column.property._
 import org.scalarelational.datatype._
 import org.scalarelational.datatype.create.OptionDataTypeCreator
+import org.scalarelational.instruction.query.TwoExpressions
 import org.scalarelational.model._
 import org.scalarelational.table.Table
 import org.scalarelational.table.property.Index
@@ -66,7 +67,7 @@ trait AbstractTableSpec extends WordSpec with Matchers {
     "create a simple query" in {
       session {
         val q = select(test.id, test.name) from test
-        q.expressions should equal ((test.id, test.name))
+        q.expressions should equal (TwoExpressions(test.id, test.name))
       }
     }
     "query the record back out" in {
@@ -83,7 +84,7 @@ trait AbstractTableSpec extends WordSpec with Matchers {
       session {
         val query = select(test.id, test.name) from test
         val results = query.result
-        results.next()() should equal ((Some(1), "John Doe"))
+        results.converted.next() should equal ((Some(1), "John Doe"))
       }
     }
     "query a record back via 'LIKE'" in {

--- a/core/src/test/scala/org/scalarelational/AbstractTableSpec.scala
+++ b/core/src/test/scala/org/scalarelational/AbstractTableSpec.scala
@@ -83,8 +83,8 @@ trait AbstractTableSpec extends WordSpec with Matchers {
     "query the record back out as a Tuple2" in {
       session {
         val query = select(test.id, test.name) from test
-        val results = query.result
-        results.converted.next() should equal ((Some(1), "John Doe"))
+        val results = query.converted
+        results.next() should equal ((Some(1), "John Doe"))
       }
     }
     "query a record back via 'LIKE'" in {

--- a/h2/src/test/scala/org/scalarelational/LinkingSpec.scala
+++ b/h2/src/test/scala/org/scalarelational/LinkingSpec.scala
@@ -43,7 +43,6 @@ class LinkingSpec extends WordSpec with Matchers {
       session {
         val result =
           (Tag.q
-            from Tag
             innerJoin ContentTagLinking on ContentTagLinking.tagId.opt === Tag.id
             where ContentTagLinking.contentId === 1
           ).result.toList

--- a/h2/src/test/scala/org/scalarelational/h2/example/ExampleSpec.scala
+++ b/h2/src/test/scala/org/scalarelational/h2/example/ExampleSpec.scala
@@ -63,7 +63,7 @@ class ExampleSpec extends WordSpec with Matchers {
       session {
         (select (Avg(rating))
           from coffees
-        ).result.converted.one.get should be > 0.0
+        ).converted.one.get should be > 0.0
       }
     }
     "query rating.avg without None" in {
@@ -72,7 +72,7 @@ class ExampleSpec extends WordSpec with Matchers {
         (select (Avg(rating))
           from coffees
           where rating.!==(None) // !== conflicts with ScalaTest
-        ).result.converted.one.get should be > 0.0
+        ).converted.one.get should be > 0.0
       }
     }
   }

--- a/h2/src/test/scala/org/scalarelational/h2/example/ExampleSpec.scala
+++ b/h2/src/test/scala/org/scalarelational/h2/example/ExampleSpec.scala
@@ -63,7 +63,7 @@ class ExampleSpec extends WordSpec with Matchers {
       session {
         (select (Avg(rating))
           from coffees
-        ).result.one.converted.get should be > 0.0
+        ).result.converted.one.get should be > 0.0
       }
     }
     "query rating.avg without None" in {
@@ -72,7 +72,7 @@ class ExampleSpec extends WordSpec with Matchers {
         (select (Avg(rating))
           from coffees
           where rating.!==(None) // !== conflicts with ScalaTest
-        ).result.one.converted.get should be > 0.0
+        ).result.converted.one.get should be > 0.0
       }
     }
   }

--- a/h2/src/test/scala/org/scalarelational/h2/modular/ModularSpec.scala
+++ b/h2/src/test/scala/org/scalarelational/h2/modular/ModularSpec.scala
@@ -104,7 +104,7 @@ class ModularSpec extends WordSpec with Matchers {
         querying should equal(0)
         queried should equal(0)
         val q = select(id, name, age, created) from users
-        q.result.converted.one should equal((1, "John Doe", 21, None))
+        q.converted.one should equal((1, "John Doe", 21, None))
         querying should equal(1)
         queried should equal(1)
       }
@@ -141,7 +141,7 @@ class ModularSpec extends WordSpec with Matchers {
         querying should equal(1)
         queried should equal(1)
         val q = select(id, name, age, created) from users
-        val result = q.result.converted.one
+        val result = q.converted.one
         result._1 should equal(2)
         result._2 should equal("Jane Doe")
         result._3 should equal(20)
@@ -173,7 +173,7 @@ class ModularSpec extends WordSpec with Matchers {
       session {
         import users._
         val q = select (id, name, created, modified) from users where id === 2
-        val result = q.result.converted.one
+        val result = q.converted.one
         result._2 should equal("updated")
         result._4.get.after(result._3.get) should be (true)
       }
@@ -184,11 +184,11 @@ class ModularSpec extends WordSpec with Matchers {
         insert(name("Jane Doe"), age(20)).result
 
         val q = select (created, modified) from users2 where id === 1
-        val result = q.result.converted.one
+        val result = q.converted.one
 
         (update(name("updated")) where id === 1).result
         val q2 = select (created, modified) from users2 where id === 1
-        val result2 = q2.result.converted.one
+        val result2 = q2.converted.one
         result2._2.after(result2._1) should be (true)
         result2._2.after(result._1) should be (true)
       }

--- a/macros/src/main/scala/org/scalarelational/compiletime/QueryMacros.scala
+++ b/macros/src/main/scala/org/scalarelational/compiletime/QueryMacros.scala
@@ -25,7 +25,7 @@ object QueryMacros {
 
     val conv = q"""
        val converter = new org.scalarelational.instruction.ResultConverter[$r] {
-         def apply(result: org.scalarelational.result.QueryResult[$r]): $r = {
+         def apply(result: org.scalarelational.result.QueryResult): $r = {
            $instance
          }
        }
@@ -48,7 +48,7 @@ object QueryMacros {
 
     val conv = q"""
        val converter = new org.scalarelational.instruction.ResultConverter[($r1, $r2)] {
-         def apply(result: org.scalarelational.result.QueryResult[($r1, $r2)]): ($r1, $r2) = {
+         def apply(result: org.scalarelational.result.QueryResult): ($r1, $r2) = {
            ($instance1, $instance2)
          }
        }
@@ -72,7 +72,7 @@ object QueryMacros {
 
     val conv = q"""
        val converter = new org.scalarelational.instruction.ResultConverter[($r1, $r2, $r3)] {
-         def apply(result: org.scalarelational.result.QueryResult[($r1, $r2, $r3)]): ($r1, $r2, $r3) = {
+         def apply(result: org.scalarelational.result.QueryResult): ($r1, $r2, $r3) = {
            ($instance1, $instance2, $instance3)
          }
        }

--- a/mapper/src/main/scala/org/scalarelational/mapper/MappedTable.scala
+++ b/mapper/src/main/scala/org/scalarelational/mapper/MappedTable.scala
@@ -19,7 +19,7 @@ abstract class MappedTable[MappedType](name: String, tableProperties: TablePrope
   def by[T, S](column: Column[T, S], value: T)
            (implicit manifest: Manifest[MappedType]) = datastore.session {
     val q = query where column === value
-    q.result.converted.headOption
+    q.converted.headOption
   }
 
   private[scalarelational] def updateColumnValues(values: List[ColumnValue[Any, Any]]): Update[Ref[MappedType]] = {

--- a/mapper/src/main/scala/org/scalarelational/mapper/package.scala
+++ b/mapper/src/main/scala/org/scalarelational/mapper/package.scala
@@ -15,7 +15,7 @@ package object mapper {
   implicit class MapperQuery[Expressions, Result](query: Query[Expressions, Result]) {
     def to[R](implicit manifest: Manifest[R]) = {
       val clazz: EnhancedClass = manifest.runtimeClass
-      val f = (r: QueryResult[R]) => {
+      val f = (r: QueryResult) => {
         clazz.create[R](r.toFieldMap)
       }
       query.convert[R](f)

--- a/mapper/src/test/scala/org/scalarelational/mapper/InheritanceSpec.scala
+++ b/mapper/src/test/scala/org/scalarelational/mapper/InheritanceSpec.scala
@@ -37,7 +37,7 @@ class InheritanceSpec extends WordSpec with Matchers {
     "query content with mapper" in {
       session {
         val query = Content.q from Content where Content.id === Some(2)
-        query.to[InheritanceDatastore.Content].result.converted.head should equal (Content("content2", Some(2)))
+        query.to[InheritanceDatastore.Content].converted.head should equal (Content("content2", Some(2)))
       }
     }
   }

--- a/mapper/src/test/scala/org/scalarelational/mapper/InheritanceSpec.scala
+++ b/mapper/src/test/scala/org/scalarelational/mapper/InheritanceSpec.scala
@@ -29,14 +29,14 @@ class InheritanceSpec extends WordSpec with Matchers {
 
     "query content" in {
       session {
-        (Content.q from Content where Content.id === Some(2))
+        (Content.q where Content.id === Some(2))
           .result.hasNext should equal (true)
       }
     }
 
     "query content with mapper" in {
       session {
-        val query = Content.q from Content where Content.id === Some(2)
+        val query = Content.q where Content.id === Some(2)
         query.to[InheritanceDatastore.Content].converted.head should equal (Content("content2", Some(2)))
       }
     }

--- a/mapper/src/test/scala/org/scalarelational/mapper/PolymorphSpec.scala
+++ b/mapper/src/test/scala/org/scalarelational/mapper/PolymorphSpec.scala
@@ -42,7 +42,7 @@ class PolymorphSpec extends WordSpec with Matchers {
     }
     "query users" in {
       session {
-        val query = users.q from users
+        val query = users.q
         val x = query.asCase[User] { row =>
           if (row(users.isGuest)) classOf[UserGuest]
           else classOf[UserAdmin]
@@ -70,7 +70,7 @@ class PolymorphSpec extends WordSpec with Matchers {
     }
     "query content" in {
       session {
-        val query = content.q from content
+        val query = content.q
         val x = query.asCase[Content] { row =>
           if (row(content.isString)) classOf[ContentString]
           else classOf[ContentList]

--- a/mapper/src/test/scala/org/scalarelational/mapper/PolymorphSpec.scala
+++ b/mapper/src/test/scala/org/scalarelational/mapper/PolymorphSpec.scala
@@ -47,7 +47,7 @@ class PolymorphSpec extends WordSpec with Matchers {
           if (row(users.isGuest)) classOf[UserGuest]
           else classOf[UserAdmin]
         }
-        insertUsers should equal (x.result.converted.toList.map(_.withoutId))
+        insertUsers should equal (x.converted.toList.map(_.withoutId))
       }
     }
   }
@@ -75,7 +75,7 @@ class PolymorphSpec extends WordSpec with Matchers {
           if (row(content.isString)) classOf[ContentString]
           else classOf[ContentList]
         }
-        insertContent should equal (x.result.converted.toList.map(_.withoutId))
+        insertContent should equal (x.converted.toList.map(_.withoutId))
       }
     }
   }

--- a/mapper/src/test/scala/org/scalarelational/mapper/basic/MapperSpec.scala
+++ b/mapper/src/test/scala/org/scalarelational/mapper/basic/MapperSpec.scala
@@ -36,39 +36,39 @@ class MapperSpec extends WordSpec with Matchers {
       "explicitly map to a case class" in {
         session {
           val query = select(*) from people where name === "John"
-          val john = query.convert[Person](qr => Person(qr(name), qr(age), qr(surname), qr(id))).result.one()
+          val john = query.convert[Person](qr => Person(qr(name), qr(age), qr(surname), qr(id))).converted.one
           john should equal(Person("John", 21, Some("Doe"), Some(1)))
 
           val query2 = select(*) from people where name === "Baby"
-          val baby = query2.convert[Person](qr => Person(qr(name), qr(age), qr(surname), qr(id))).result.one()
+          val baby = query2.convert[Person](qr => Person(qr(name), qr(age), qr(surname), qr(id))).converted.one
           baby should equal(Person("Baby", 21, None, Some(3)))
         }
       }
       "explicitly map to a (Name, Age) type" in {
         session {
           val query = select(*) from people where name === "John"
-          val john = query.convert[(Name, Age)](qr => (Name(qr(name)), Age(qr(age)))).result.head()
+          val john = query.convert[(Name, Age)](qr => (Name(qr(name)), Age(qr(age)))).converted.head
           john should equal((Name("John"), Age(21)))
         }
       }
       "automatically map to a case class" in {
         session {
           val query = select(*) from people where name === "Jane"
-          val jane = query.to[Person].result.head()
+          val jane = query.to[Person].converted.head
           jane should equal(Person("Jane", 19, Some("Doe"), Some(2)))
         }
       }
       "automatically map to a case class with Macro" in {
         session {
           val query = select(*) from people where name === "Jane"
-          val jane = query.toMacro[Person](people).result.head()
+          val jane = query.toMacro[Person](people).converted.head
           jane should equal(Person("Jane", 19, Some("Doe"), Some(2)))
         }
       }
       "automatically map a subset of columns to a case class" in {
         session {
           val query = select(*) from people where name === "Jane"
-          val jane = query.to[PartialPerson].result.head()
+          val jane = query.to[PartialPerson].converted.head
           jane should equal(PartialPerson("Jane", 19, Some(2)))
         }
       }
@@ -98,7 +98,7 @@ class MapperSpec extends WordSpec with Matchers {
 
         session {
           val query = select(*) from people where name === "Ray"
-          val ray = query.to[Person].result.head()
+          val ray = query.to[Person].converted.head
           ray should equal(Person("Ray", 30, None, Some(4)))
         }
       }
@@ -114,7 +114,7 @@ class MapperSpec extends WordSpec with Matchers {
           val query1 = select(*) from people where name === "Ray"
           query1.to[Person].result.headOption should equal(None)
           val query2 = select(*) from people where name === "Jay"
-          val jay = query2.to[Person].result.head()
+          val jay = query2.to[Person].converted.head
           jay should equal(Person("Jay", 30, None, Some(4)))
         }
       }
@@ -139,7 +139,7 @@ class MapperSpec extends WordSpec with Matchers {
       "query back 'French Roast' with 'Superior Coffee'" in {
         session {
           val query = select(coffees.* ::: suppliers.*) from coffees innerJoin suppliers on (coffees.supId === suppliers.ref.opt) where (coffees.name === "French Roast")
-          val (frenchRoast, superior) = query.to[Coffee, Supplier](coffees, suppliers).result.head()
+          val (frenchRoast, superior) = query.to[Coffee, Supplier](coffees, suppliers).converted.head
           frenchRoast should equal(Coffee("French Roast", Some(superior.ref), 8.99, 0, 0, Some(2)))
           superior should equal(Supplier("Superior Coffee", "1 Party Place", "Mendocino", "CA", "95460", Some(2)))
         }
@@ -148,7 +148,7 @@ class MapperSpec extends WordSpec with Matchers {
         session {
           import coffees._
           val query = select (*) from coffees where name === "Caffè American"
-          val caffe = query.to[Coffee].result.head()
+          val caffe = query.to[Coffee].converted.head
           caffe should equal(Coffee("Caffè American", None, 12.99, 0, 0, Some(6)))
         }
       }
@@ -171,7 +171,7 @@ class MapperSpec extends WordSpec with Matchers {
             orderBy
               coffees.id.asc
           )
-          val results = query.to[Coffee, Option[Supplier]](coffees, suppliers).result.converted.toVector
+          val results = query.to[Coffee, Option[Supplier]](coffees, suppliers).converted.toVector
           results.length should equal(6)
           check(results.head, "Colombian", Some("Acme, Inc."))
           check(results(1), "French Roast", Some("Superior Coffee"))
@@ -223,14 +223,14 @@ class MapperSpec extends WordSpec with Matchers {
       "find and delete Jane Doe" in {
         session {
           val query = select(*) from people where name === "Jane"
-          val jane = query.to[Person].result.head()
+          val jane = query.to[Person].converted.head
           jane.delete.result
         }
       }
       "no longer find Jane Doe" in {
         session {
           val query = select(*) from people where name === "Jane"
-          query.to[Person].result.converted.headOption should equal(None)
+          query.to[Person].converted.headOption should equal(None)
         }
       }
     }

--- a/mapper/src/test/scala/org/scalarelational/mapper/gettingstarted/GettingStartedSpec.scala
+++ b/mapper/src/test/scala/org/scalarelational/mapper/gettingstarted/GettingStartedSpec.scala
@@ -66,7 +66,7 @@ class GettingStartedSpec extends WordSpec with Matchers {
         check(results(4), "COFFEES(COF_NAME: French Roast Decaf, SUP_ID: 2, PRICE: 9.99, SALES: 0, TOTAL: 0, COF_ID: Some(5))")
       }
 
-      def check(result: QueryResult[_], expected: String) = {
+      def check(result: QueryResult, expected: String) = {
         val s = result.toString
         s should equal(expected)
       }
@@ -77,7 +77,7 @@ class GettingStartedSpec extends WordSpec with Matchers {
       session {
         val query = select (c.name, c.supID, c.price, c.sales, c.total) from coffees
 
-        query.result.converted.map {
+        query.converted.map {
           case (name, supID, price, sales, total) => s"$name  $supID  $price  $sales  $total"
         }.mkString("\n")
       }
@@ -91,11 +91,11 @@ class GettingStartedSpec extends WordSpec with Matchers {
             on coffees.supID === suppliers.ref
             where coffees.price < 9.0
         )
-        val results = query.result.toVector
+        val results = query.converted.toVector
         results.length should equal(3)
-        results(0)() should equal(("Colombian", "Acme, Inc."))
-        results(1)() should equal(("French Roast", "Superior Coffee"))
-        results(2)() should equal(("Colombian Decaf", "Acme, Inc."))
+        results(0) should equal(("Colombian", "Acme, Inc."))
+        results(1) should equal(("French Roast", "Superior Coffee"))
+        results(2) should equal(("Colombian Decaf", "Acme, Inc."))
       }
     }
   }
@@ -113,7 +113,7 @@ class GettingStartedSpec extends WordSpec with Matchers {
         import suppliers._
 
         val query = select (*) from suppliers where name === "Starbucks"
-        val starbucks = query.to[Supplier].result.head()
+        val starbucks = query.to[Supplier].converted.head
         starbucks should equal (Supplier("Starbucks", "123 Everywhere Rd.", "Lotsaplaces", Some("CA"), "93966", Status.Enabled, Some(4)))
       }
     }
@@ -122,7 +122,7 @@ class GettingStartedSpec extends WordSpec with Matchers {
         import suppliers._
 
         val query = select(name, street, city, state, zip, status, id) from suppliers where name === "Starbucks"
-        val starbucksTuple = query.result.head()
+        val starbucksTuple = query.converted.head
         // Because we explicitly defined the expressions we want back we can extract the results as a type-safe Tuple.
         starbucksTuple should equal(("Starbucks", "123 Everywhere Rd.", "Lotsaplaces", Some("CA"), "93966", Status.Enabled, Some(4)))
         // Use our modified Tuple to create an instance of the Supplier
@@ -138,14 +138,14 @@ class GettingStartedSpec extends WordSpec with Matchers {
         val query = select(name, street, city, state, zip, status, id) from suppliers where name === "Starbucks"
         // We can map this in our Query to the end resulting type without all the mess using Query.map
         val updated = query.map(Supplier.tupled)
-        val starbucks = updated.result.head()
+        val starbucks = updated.converted.head
         starbucks should equal(Supplier("Starbucks", "123 Everywhere Rd.", "Lotsaplaces", Some("CA"), "93966", Status.Enabled, Some(4)))
       }
     }
     "Query 'French Roast' with 'Superior Coffee' for (Coffee, Supplier)" in {
       session {
         val query = select (coffees.* ::: suppliers.*) from coffees innerJoin suppliers on (coffees.supID === suppliers.ref) where coffees.name === "French Roast"
-        val (frenchRoast, superior) = query.to[Coffee, Supplier](coffees, suppliers).result.head()
+        val (frenchRoast, superior) = query.to[Coffee, Supplier](coffees, suppliers).converted.head
         frenchRoast should equal(Coffee("French Roast", superior.ref, 8.99, 0, 0, Some(2)))
         superior should equal(Supplier("Superior Coffee", "1 Party Place", "Mendocino", None, "95460", Status.Unconfirmed, Some(2)))
       }

--- a/mapper/src/test/scala/org/scalarelational/mapper/model/ModelSpec.scala
+++ b/mapper/src/test/scala/org/scalarelational/mapper/model/ModelSpec.scala
@@ -1,4 +1,4 @@
-package org.scalarelational.mapper
+package org.scalarelational.mapper.model
 
 import java.sql.Timestamp
 
@@ -9,8 +9,8 @@ import org.scalarelational.table.Table
 import org.scalatest.{Matchers, WordSpec}
 
 /**
- * @author Matt Hicks <matt@outr.com>
- */
+  * @author Matt Hicks <matt@outr.com>
+  */
 class ModelSpec extends WordSpec with Matchers {
   import ModelDatastore._
 


### PR DESCRIPTION
Somewhat simplifies the query structure and creates a `converted` method along-side `result` in `Query`. I'm open to an alternative naming convention.